### PR TITLE
Optionally use a proxy process to spawn subprocesses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+# Makefile for CodeJail
+
+test: test_no_proxy test_proxy
+
+test_no_proxy:
+	@echo "Running all tests with no proxy process"
+	CODEJAIL_PROXY=0 nosetests
+
+test_proxy:
+	@echo "Running all tests with proxy process"
+	CODEJAIL_PROXY=1 nosetests

--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,9 @@ the rights to modify the files in its site-packages directory.
 Tests
 -----
 
-The tests run under nose in the standard fashion.
+Run the tests with the Makefile::
+
+    $ make tests
 
 If CodeJail is running unsafely, many of the tests will be automatically
 skipped, or will fail, depending on whether CodeJail thinks it should be in

--- a/codejail/django_integration.py
+++ b/codejail/django_integration.py
@@ -24,7 +24,9 @@ class ConfigureCodeJailMiddleware(object):
         if python_bin:
             user = settings.CODE_JAIL['user']
             codejail.jail_code.configure("python", python_bin, user=user)
+
         limits = settings.CODE_JAIL.get('limits', {})
         for name, value in limits.items():
             codejail.jail_code.set_limit(name, value)
+
         raise MiddlewareNotUsed

--- a/codejail/proxy.py
+++ b/codejail/proxy.py
@@ -1,0 +1,183 @@
+"""A proxy subprocess-making process for CodeJail."""
+
+import ast
+import logging
+import os
+import os.path
+import subprocess
+import sys
+import time
+
+from .subproc import run_subprocess
+
+log = logging.getLogger("codejail")
+
+# We use .readline to get data from the pipes between the processes, so we need
+# to ensure that a newline does not appear in the data.  We also need a way to
+# communicate a few values, and unpack them.  Lastly, we need to be sure we can
+# handle binary data.  Serializing with repr() and deserializing the literals
+# that result give us all the properties we need.
+serialize = repr
+deserialize = ast.literal_eval
+
+##
+## Client code, runs in the parent CodeJail process.
+##
+
+def run_subprocess_through_proxy(*args, **kwargs):
+    """
+    Works just like :ref:`run_subprocess`, but through the proxy process.
+
+    This will retry a few times if need be.
+
+    """
+    for tries in xrange(3):
+        try:
+            proxy = get_proxy()
+
+            # Write the args and kwargs to the proxy process.
+            proxy_stdin = serialize((args, kwargs))
+            proxy.stdin.write(proxy_stdin+"\n")
+
+            # Read the result from the proxy.  This blocks until the process
+            # is done.
+            proxy_stdout = proxy.stdout.readline()
+            if not proxy_stdout:
+                # EOF: the proxy must have died.
+                raise Exception("Proxy process died unexpectedly!")
+            status, stdout, stderr, log_calls = deserialize(proxy_stdout.rstrip())
+
+            # Write all the log messages to the log, and return.
+            for level, msg, args in log_calls:
+                log.log(level, msg, *args)
+            return status, stdout, stderr
+        except Exception as e:
+            log.exception("Proxy process failed")
+            # Give the proxy process a chance to die completely if it is dying.
+            time.sleep(.001)
+            continue
+
+    # If we finished all the tries, then raise the last exception we got.
+    raise
+
+
+# There is one global proxy process.
+PROXY_PROCESS = None
+
+def get_proxy():
+    global PROXY_PROCESS
+
+    # If we had a proxy process, but it died, clean up.
+    if PROXY_PROCESS is not None:
+        status = PROXY_PROCESS.poll()
+        if status is not None:
+            log.info(
+                "CodeJail proxy process (pid %d) ended with status code %d",
+                PROXY_PROCESS.pid,
+                status
+            )
+            PROXY_PROCESS = None
+
+    # If we need a proxy, make a proxy.
+    if PROXY_PROCESS is None:
+        # Start the proxy by invoking proxy_main.py in our root directory.
+        root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        proxy_main_py = os.path.join(root, "proxy_main.py")
+
+        # Run proxy_main.py with the same Python that is running us. "-u" makes
+        # the stdin and stdout unbuffered. We pass the log level of the
+        # "codejail" log so that the proxy can send back an appropriate level
+        # of detail in the log messages.
+        log_level = log.getEffectiveLevel()
+        cmd = [sys.executable, '-u', proxy_main_py, str(log_level)]
+
+        PROXY_PROCESS = subprocess.Popen(
+            args=cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            )
+
+        log.info("Started CodeJail proxy process (pid %d)", PROXY_PROCESS.pid)
+
+    return PROXY_PROCESS
+
+##
+## Proxy process code
+##
+
+
+class CapturingHandler(logging.Handler):
+    """
+    A logging Handler that captures all the log calls, for later replay.
+
+    NOTE: this doesn't capture all aspects of the log record.  It only captures
+    the log level, the message string, and the arguments.  It does not capture
+    the caller, the current exception, the current time, etc.
+
+    """
+    def __init__(self):
+        super(CapturingHandler, self).__init__()
+        self.log_calls = []
+
+    def createLock(self):
+        self.lock = None
+
+    def handle(self, record):
+        self.log_calls.append((record.levelno, record.msg, record.args))
+
+    def get_log_calls(self):
+        retval = self.log_calls
+        self.log_calls = []
+        return retval
+
+
+def proxy_main(argv):
+    """
+    The main program for the proxy process.
+
+    It does this:
+
+        * Reads a line from stdin with the repr of a tuple: (args, kwargs)
+        * Calls :ref:`run_subprocess` with *args, **kwargs
+        * Writes one line to stdout: the repr of the return value from
+          `run_subprocess` and the log calls made:
+          (status, stdout, stderr, log_calls) .
+
+    The process ends when its stdin is closed.
+
+    `argv` is the argument list of the process, from sys.argv. The only
+    argument is the logging level for the "codejail" log in the parent
+    process. Since we tunnel our logging back to the parent, we don't want to
+    send everything, just the records that the parent will actually log.
+
+    """
+    # We don't want to see any noise on stderr.
+    sys.stderr = open(os.devnull, "w")
+
+    # Capture all logging messages.
+    capture_log = CapturingHandler()
+    log.addHandler(capture_log)
+    log.setLevel(int(argv[1]) or logging.DEBUG)
+
+    log.debug("Starting proxy process")
+
+    try:
+        while True:
+            stdin = sys.stdin.readline()
+            log.debug("proxy stdin: %r" % stdin)
+            if not stdin:
+                break
+            args, kwargs = deserialize(stdin.rstrip())
+            status, stdout, stderr = run_subprocess(*args, **kwargs)
+            log.debug("run_subprocess result: status=%r\nstdout=%r\nstderr=%r" % (status, stdout, stderr))
+            log_calls = capture_log.get_log_calls()
+            stdout = serialize((status, stdout, stderr, log_calls))
+            sys.stdout.write(stdout+"\n")
+    except Exception:
+        # Note that this log message will not get back to the parent, because
+        # we are dying and not communicating back to the parent. This will be
+        # useful only if you add another handler at the top of this function.
+        log.exception("Proxy dying due to exception")
+
+    log.debug("Exiting proxy process")

--- a/codejail/safe_exec.py
+++ b/codejail/safe_exec.py
@@ -14,7 +14,7 @@ except ImportError:
 from codejail import jail_code
 from codejail.util import temp_directory, change_directory
 
-log = logging.getLogger(__name__)
+log = logging.getLogger("codejail")
 
 
 # Flags to let developers temporarily change some behavior in this file.

--- a/codejail/subproc.py
+++ b/codejail/subproc.py
@@ -1,0 +1,93 @@
+"""Subprocess helpers for CodeJail."""
+
+import functools
+import logging
+import os
+import resource
+import subprocess
+import threading
+import time
+
+log = logging.getLogger("codejail")
+
+
+def run_subprocess(
+    cmd, stdin=None, cwd=None, env=None, rlimits=None, realtime=None,
+    slug=None,
+):
+    """
+    A helper to make a limited subprocess.
+
+    `cmd`, `cwd`, and `env` are exactly as `subprocess.Popen` expects.
+
+    `stdin` is the data to write to the stdin of the subprocess.
+
+    `rlimits` is a list of tuples, the arguments to pass to
+    `resource.setrlimit` to set limits on the process.
+
+    `realtime` is the number of seconds to limit the execution of the process.
+
+    `slug` is a short identifier for use in log messages.
+
+    This function waits until the process has finished executing before
+    returning.
+
+    Returns a tuple of three values: the exit status code of the process, and
+    the stdout and stderr of the process, as strings.
+
+    """
+    subproc = subprocess.Popen(
+        cmd, cwd=cwd, env=env,
+        preexec_fn=functools.partial(set_process_limits, rlimits or ()),
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+
+    if slug:
+        log.info("Executed jailed code %s in %s, with PID %s", slug, cwd, subproc.pid)
+
+    # Start the time killer thread.
+    if realtime:
+        killer = ProcessKillerThread(subproc, limit=realtime)
+        killer.start()
+
+    stdout, stderr = subproc.communicate(stdin)
+    return subproc.returncode, stdout, stderr
+
+
+def set_process_limits(rlimits):       # pragma: no cover
+    """
+    Set limits on this process, to be used first in a child process.
+    """
+    # Set a new session id so that this process and all its children will be
+    # in a new process group, so we can kill them all later if we need to.
+    os.setsid()
+
+    for limit, value in rlimits:
+        resource.setrlimit(limit, value)
+
+
+class ProcessKillerThread(threading.Thread):
+    """
+    A thread to kill a process after a given time limit.
+    """
+    def __init__(self, subproc, limit):
+        super(ProcessKillerThread, self).__init__()
+        self.subproc = subproc
+        self.limit = limit
+
+    def run(self):
+        start = time.time()
+        while (time.time() - start) < self.limit:
+            time.sleep(.25)
+            if self.subproc.poll() is not None:
+                # Process ended, no need for us any more.
+                return
+
+        if self.subproc.poll() is None:
+            # Can't use subproc.kill because we launched the subproc with sudo.
+            pgid = os.getpgid(self.subproc.pid)
+            log.warning(
+                "Killing process %r (group %r), ran too long: %.1fs",
+                self.subproc.pid, pgid, time.time() - start
+            )
+            subprocess.call(["sudo", "pkill", "-9", "-g", str(pgid)])

--- a/memory_stress.py
+++ b/memory_stress.py
@@ -1,0 +1,18 @@
+"""Memory-stress a long-running CodeJail-using process."""
+
+from codejail import safe_exec
+
+GOBBLE_CHUNK = int(1e7)
+
+def main():
+    gobble = []
+    for i in xrange(int(1e7)):
+        print i
+        globs = {}
+        safe_exec.safe_exec("a = 17", globs)
+        assert globs["a"] == 17
+
+        gobble.append("x"*GOBBLE_CHUNK)
+
+if __name__ == "__main__":
+    main()

--- a/proxy_main.py
+++ b/proxy_main.py
@@ -1,0 +1,8 @@
+"""The main program for the proxy process."""
+
+import sys
+
+from codejail.proxy import proxy_main
+
+if __name__ == "__main__":
+    sys.exit(proxy_main(sys.argv))


### PR DESCRIPTION
When spawning subprocesses, fork() will fail if the memory of the parent
can't be duplicated in the child. This means large long-lived processes
will have problems using CodeJail repeatedly.

This introduces a long-lived proxy subprocess which then spawns the
actual subprocesses.  Because the proxy process starts small and stays
small, it will be able to spawn subprocesses even when the parent
process grows large.

The use of the proxy process is controlled by a "PROXY" limit, which
should be 0 or 1.  If neither is set, then the CODEJAIL_PROXY
environment variable determines whether the proxy is used.

BTW: before the rebase, the head was
0e9c49336d5b2c10d1429559c640d37d6eea171c if you want to see the
progression of commits to get this to work. :)