### PR TITLE
Adam/test middleware

### DIFF
--- a/codejail/django_integration.py
+++ b/codejail/django_integration.py
@@ -3,7 +3,6 @@
 Code to glue codejail into a Django environment.
 
 """
-
 from django.core.exceptions import MiddlewareNotUsed
 from django.conf import settings
 
@@ -28,5 +27,8 @@ class ConfigureCodeJailMiddleware(object):
         limits = settings.CODE_JAIL.get('limits', {})
         for name, value in limits.items():
             codejail.jail_code.set_limit(name, value)
+
+        # if using a proxy, start it up now
+        codjail.jail_code.startup()
 
         raise MiddlewareNotUsed


### PR DESCRIPTION
This PR introduces a change to initialize the proxy process very soon after the parent process starts up. Since we load the XML modulestore into memory, we save on memory by forking before that happens

@nedbat 
@maxrothman 
@feanil 

