### PR TITLE
(WIP) Adding java using Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ htmlcov
 
 # OS detritus
 *.DS_Store
+
+/.vagrant/
+/dist/

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,5 @@ James Tauber <jtauber@jtauber.com>
 Piotr Mitros <pmitros@edx.org>
 Feanil Patel <feanil@edx.org>
 Dave St.Germain <dstgermain@edx.org>
+Omar Al-Ithawi <i@omardo.com>
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  # config.vm.network "private_network", ip: "192.168.33.240"
+
+  config.vm.synced_folder ".", "/home/vagrant/codejail"
+    #, type: "nfs",
+    # mount_options: ['rw', 'vers=3', 'tcp', 'fsc' ,'actimeo=2']
+
+  config.vm.provision "shell", path: "vagrant/provision.sh"
+end

--- a/vagrant/inside_vagrant_test.py
+++ b/vagrant/inside_vagrant_test.py
@@ -1,0 +1,43 @@
+import unittest
+from codejail import jail_code
+from codejail.safe_exec import SafeExecException, safe_exec
+
+
+class VagrantCodeJailTest(unittest.TestCase):
+    """Very simple test for the codejail in Vagrant."""
+
+    def setUp(self):
+        jail_code.configure(
+            command='python',
+            bin_path='/home/vagrant/sandboxenv/bin/python',
+            user='sandbox',
+        )
+
+    def run_basic_python_test(self):
+        try:
+            safe_exec("import os", {}, slug='basic_test')
+        except SafeExecException:
+            self.fail("`import os` have raised an unwanted SafeExecException!")
+
+    @unittest.skip
+    def basic_java_call_test(self):
+        def run_unauthorized():
+            """
+            Runs an unauthorized java command.
+            """
+            jail_code.jail_code("java", slug='access_denied_java')
+
+        self.assertRaises(SafeExecException, run_unauthorized)
+
+    def process_restriction_test(self):
+        def run_unauthorized():
+            """
+            Runs an unauthorized code that should fail an exception.
+            """
+            safe_exec(
+                "import os\nos.system('ls /etc')",
+                {},
+                slug='access_denied_python',
+            )
+
+        self.assertRaises(Exception, run_unauthorized)

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -94,6 +94,7 @@ make_jailenv_env
 
 
 sudo bash -e <<TEST
+cd ~/codejail/
 source ~/jailenv/bin/activate
 nosetests vagrant/
 TEST

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -e
+
+export DEBIAN_FRONTEND=noninteractive
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPT_DIR/..
+
+
+sudo apt-get update
+sudo apt-get install -y virtualenvwrapper
+sudo apt-get install -y python-dev python-numpy python-scipy
+
+sudo bash -e <<BASH
+    cd /home/vagrant/
+    virtualenv sandboxenv
+
+    source sandboxenv/bin/activate
+
+    cd codejail
+
+    pip install -r vagrant/requirements/fake-sandbox.txt
+BASH
+
+sudo addgroup sandbox
+sudo adduser --gecos --disabled-login sandbox --ingroup sandbox
+
+sudo addgroup www-data
+sudo adduser --gecos --disabled-login www-data --ingroup www-data
+
+SANDBOX_FILE=`mktemp`
+
+sudo tee $SANDBOX_FILE <<SUDOERS
+    www-data ALL=(sandbox)  SETENV:NOPASSWD:/home/vagrant/sandboxenv/bin/python
+    www-data ALL=(sandbox)  SETENV:NOPASSWD:/usr/bin/find /tmp/codejail-*/tmp -mindepth 1 -maxdepth 1 -exec rm -rf {} ;
+    www-data ALL=(ALL) NOPASSWD:/bin/kill
+    www-data ALL=(ALL) NOPASSWD:/usr/bin/pkill
+SUDOERS
+
+cat $SANDBOX_FILE | sudo EDITOR='tee -a' -- visudo -f /etc/sudoers.d/01-sandbox
+
+rm $SANDBOX_FILE
+
+sudo apt-get install -y apparmor apparmor-utils
+
+sudo tee /etc/apparmor.d/home.vagrant.sandboxenv.bin.python <<ARMOR
+#include <tunables/global>
+
+/home/vagrant/sandboxenv/bin/python {
+    #include <abstractions/base>
+
+    /home/vagrant/sandboxenv/** mr,
+    /home/vagrant/sandboxenv/lib/python2.7/** r,
+    /tmp/codejail-*/ rix,
+    /tmp/codejail-*/** wrix,
+
+    #
+    # Whitelist particiclar shared objects from the system
+    # python installation
+    #
+    /usr/lib/python2.7/lib-dynload/_json.so mr,
+    /usr/lib/python2.7/lib-dynload/_ctypes.so mr,
+    /usr/lib/python2.7/lib-dynload/_heapq.so mr,
+    /usr/lib/python2.7/lib-dynload/_io.so mr,
+    /usr/lib/python2.7/lib-dynload/_csv.so mr,
+    /usr/lib/python2.7/lib-dynload/datetime.so mr,
+    /usr/lib/python2.7/lib-dynload/_elementtree.so mr,
+    /usr/lib/python2.7/lib-dynload/pyexpat.so mr,
+
+    #
+    # Allow access to selections from /proc
+    #
+    /proc/*/mounts r,
+
+}
+ARMOR
+
+sudo apparmor_parser /etc/apparmor.d/home.vagrant.sandboxenv.bin.python
+# Use to disable `aa-complain /etc/apparmor.d/home.vagrant.sandboxenv.bin.python`
+sudo aa-enforce /etc/apparmor.d/home.vagrant.sandboxenv.bin.python
+
+make_jailenv_env() {
+  cd ~
+  virtualenv --system-site-packages jailenv
+  source ~/jailenv/bin/activate
+
+  cd codejail/
+
+  python setup.py install
+  pip install -r vagrant/requirements/codejail.txt
+}
+
+make_jailenv_env
+
+
+sudo bash -e <<TEST
+source ~/jailenv/bin/activate
+nosetests vagrant/
+TEST

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -79,6 +79,9 @@ sudo apparmor_parser /etc/apparmor.d/home.vagrant.sandboxenv.bin.python
 # Use to disable `aa-complain /etc/apparmor.d/home.vagrant.sandboxenv.bin.python`
 sudo aa-enforce /etc/apparmor.d/home.vagrant.sandboxenv.bin.python
 
+sudo apt-get install -y libblas-dev libatlas3-base-dev liblapack-dev
+
+sudo update-alternatives --set liblapack.so.3 /usr/lib/lapack/liblapack.so.3
 make_jailenv_env() {
   cd ~
   virtualenv --system-site-packages jailenv

--- a/vagrant/requirements/codejail.txt
+++ b/vagrant/requirements/codejail.txt
@@ -1,0 +1,3 @@
+nose
+mock
+# scipy and numy are installed using apt-get

--- a/vagrant/requirements/fake-sandbox.txt
+++ b/vagrant/requirements/fake-sandbox.txt
@@ -1,0 +1,5 @@
+requests
+numpy
+scipy
+nose
+mock


### PR DESCRIPTION
I'm trying to [add Java to the codejail](https://groups.google.com/d/msg/edx-code/1UvhE0DNclk/npuTavlKAAAJ).

In order to avoid ruining my machine while fiddling with AppArmor I'm using Vagrant.

I'm still not sure how to run a basic python code. To illustrate it the following describes the bug:

 - Run `$ vagrant up`
 - If something fails from the provision you can still run that portion manually in the `vagrant/provision.sh` code.
 - Run this script `sudo bash -c '$ cd ~/codejail/ && source ~/jailenv/bin/activate && nosetests vagrant/`

**Expected:**
 - The tests should run OK and everything should be rosy

**Actual:**
 - Well, not everything is rosy because the CodeJail is not jailing the python's `ls /etc`.'

I'm sure that I have not configured the sandbox correctly, so I will check the [configuration](https://github.com/edx/configuration) repo to see if I have done the correct steps.