### PR TITLE
Fix command line handling so it works when no user is specified.

### DIFF
--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -179,6 +179,7 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
         os.chmod(tmptmp, 0777)
 
         argv = argv or []
+        env = {'TMPDIR': 'tmp'}
 
         # All the supporting files are copied into our directory.
         for filename in files or ():
@@ -209,11 +210,9 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
         user = COMMANDS[command]['user']
         if user:
             # Run as the specified user
-            cmd.extend(['sudo', '-u', user])
+            cmd.extend(['sudo', '-u', user, 'TMPDIR=tmp'])
             rm_cmd.extend(['sudo', '-u', user])
 
-        # Point TMPDIR at our temp directory.
-        cmd.extend(['TMPDIR=tmp'])
         # Start with the command line dictated by "python" or whatever.
         cmd.extend(COMMANDS[command]['cmdline_start'])
 
@@ -232,7 +231,7 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
 
         # Run the subprocess.
         status, stdout, stderr = run_subprocess_fn(
-            cmd=cmd, cwd=homedir, env={}, slug=slug,
+            cmd=cmd, cwd=homedir, env=env, slug=slug,
             stdin=stdin,
             realtime=LIMITS["REALTIME"], rlimits=create_rlimits(),
             )

--- a/codejail/tests/helpers.py
+++ b/codejail/tests/helpers.py
@@ -1,0 +1,30 @@
+"""
+Helper code to facilitate testing
+"""
+
+from contextlib import contextmanager
+
+from codejail import jail_code
+
+SAME = object()
+
+
+@contextmanager
+def override_configuration(command, bin_path, user):
+    """
+    Context manager to temporarily alter the configuration of a codejail
+    command.
+    """
+    old = jail_code.COMMANDS.get(command)
+    if bin_path is SAME:
+        bin_path = old['cmdline_start'][0]
+    if user is SAME:
+        user = old['user']
+    try:
+        jail_code.configure(command, bin_path, user)
+        yield
+    finally:
+        if old is None:
+            del jail_code.COMMANDS[command]
+        else:
+            jail_code.COMMANDS[command] = old

--- a/pylintrc
+++ b/pylintrc
@@ -169,7 +169,7 @@ notes=FIXME,XXX,TODO
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=79
+max-line-length=120
 
 # Maximum number of lines in a module
 max-module-lines=1000


### PR DESCRIPTION
`subprocess` tries to treat `TMPDIR=tmp` as the executable if it is passed as the first argument, and raises an `OSError` because no file by that name exists.  This moves the environment variable to the environment, where it belongs, but adds it to the sudo command when that is supplied to work around oddities in sudo's environment handling.  This work is preparatory to [TNL-4843](https://openedx.atlassian.net/browse/TNL-4843).

### Tests

- [x] Unit tests
- [x] Manually tested

### Reviewers:

- [x] @nedbat 
- [x] @efischer

### FYI:

@edx/devops : Because codejail delves into user permissions, system configuration, and other things that are generally in your wheelhouse, I want you to be aware of what I'm up to, and can stop me if I do something crazy.

## Post review

- [x] Squash commits