### PR TITLE
requirements for building sandboxes

### DIFF
--- a/requirements/sandbox.txt
+++ b/requirements/sandbox.txt
@@ -1,0 +1,4 @@
+# These requirements should be installed during the creation
+# of sandboxes used for testing codejail
+django==1.11.22
+numpy==1.16.4


### PR DESCRIPTION
Adding the two dependencies used in testing codejail sandboxes. These need to be installed in the sandboxes before AppArmor is activated.