### PR TITLE
python modernize pt 2

### DIFF
--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -245,6 +245,9 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
         else:
             run_subprocess_fn = run_subprocess
 
+        if stdin:
+            stdin = bytes(stdin, 'utf-8')
+
         # Run the subprocess.
         status, stdout, stderr = run_subprocess_fn(
             cmd=cmd, cwd=homedir, env={}, slug=slug,

--- a/codejail/tests/test_jail_code.py
+++ b/codejail/tests/test_jail_code.py
@@ -14,6 +14,8 @@ import time
 import unittest
 
 import mock
+import six
+from builtins import bytes
 from nose.plugins.skip import SkipTest
 
 from codejail.jail_code import jail_code, is_configured, set_limit, LIMITS
@@ -73,46 +75,60 @@ class TestFeatures(JailCodeHelpers, unittest.TestCase):
     """Test features of how `jail_code` runs Python."""
 
     def test_hello_world(self):
-        res = jailpy(code="print 'Hello, world!'")
+        res = jailpy(code="""
+            from __future__ import print_function; print('Hello, world!')
+        """)
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, 'Hello, world!\n')
+        self.assertEqual(res.stdout, b'Hello, world!\n')
 
     def test_argv(self):
         set_limit('REALTIME', 2)
         res = jailpy(
-            code="import sys; print ':'.join(sys.argv[1:])",
+            code="""
+                from __future__ import print_function
+                import sys
+                print(':'.join(sys.argv[1:]))
+            """,
             argv=["Hello", "world", "-x"],
             slug="a/useful/slug",
         )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "Hello:world:-x\n")
+        self.assertEqual(res.stdout, b"Hello:world:-x\n")
 
     def test_ends_with_exception(self):
         res = jailpy(code="""raise Exception('FAIL')""")
         self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "")
-        self.assertEqual(res.stderr, textwrap.dedent("""\
+        self.assertEqual(res.stdout, b"")
+        self.assertEqual(res.stderr, bytes(textwrap.dedent("""\
             Traceback (most recent call last):
               File "jailed_code", line 1, in <module>
                 raise Exception('FAIL')
             Exception: FAIL
-            """))
+            """), 'utf-8'))
 
     def test_stdin_is_provided(self):
         res = jailpy(
-            code="import json,sys; print sum(json.load(sys.stdin))",
+            code="""
+                from __future__ import print_function
+                import json, sys
+                print(sum(json.load(sys.stdin)))
+            """,
             stdin="[1, 2.5, 33]"
         )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "36.5\n")
+        self.assertEqual(res.stdout, b"36.5\n")
 
     def test_stdin_can_be_large_and_binary(self):
         res = jailpy(
-            code="import sys; print sum(ord(c) for c in sys.stdin.read())",
+            code="""
+                from __future__ import print_function
+                import sys
+                print(sum(ord(c) for c in sys.stdin.read()))
+            """,
             stdin="".join(chr(i) for i in range(256))*10000,
         )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "326400000\n")
+        self.assertEqual(res.stdout, b"326400000\n")
 
     def test_stdout_can_be_large_and_binary(self):
         res = jailpy(
@@ -124,7 +140,7 @@ class TestFeatures(JailCodeHelpers, unittest.TestCase):
         self.assertResultOk(res)
         self.assertEqual(
             res.stdout,
-            "".join(chr(i) for i in range(256))*10000
+            bytes("".join(chr(i) for i in range(256))*10000, 'utf-8')
         )
 
     def test_stderr_can_be_large_and_binary(self):
@@ -136,38 +152,42 @@ class TestFeatures(JailCodeHelpers, unittest.TestCase):
             """
         )
         self.assertEqual(res.status, 0)
-        self.assertEqual(res.stdout, "OK!")
+        self.assertEqual(res.stdout, b"OK!")
         self.assertEqual(
             res.stderr,
-            "".join(chr(i) for i in range(256))*10000
+            bytes("".join(chr(i) for i in range(256))*10000, 'utf-8')
         )
 
     def test_files_are_copied(self):
         res = jailpy(
-            code="print 'Look:', open('hello.txt').read()",
+            code="""
+                from __future__ import print_function
+                print('Look:', open('hello.txt').read())
+            """,
             files=[file_here("hello.txt")]
         )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, 'Look: Hello there.\n\n')
+        self.assertEqual(res.stdout, b'Look: Hello there.\n\n')
 
     def test_directories_are_copied(self):
         res = jailpy(
             code="""\
+                from __future__ import print_function
                 import os
                 res = []
                 for path, dirs, files in os.walk("."):
                     res.append((path, sorted(dirs), sorted(files)))
                 for row in sorted(res):
-                    print row
+                    print(row)
                 """,
             files=[file_here("hello.txt"), file_here("pylib")]
         )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, textwrap.dedent("""\
+        self.assertEqual(res.stdout, bytes(textwrap.dedent("""\
             ('.', ['pylib', 'tmp'], ['hello.txt', 'jailed_code'])
             ('./pylib', [], ['module.py'])
             ('./tmp', [], [])
-            """))
+            """), 'utf-8'))
 
     def test_executing_a_copied_file(self):
         res = jailpy(
@@ -177,27 +197,34 @@ class TestFeatures(JailCodeHelpers, unittest.TestCase):
         self.assertResultOk(res)
         self.assertEqual(
             res.stdout,
-            "This is doit.py!\nMy args are ['doit.py', '1', '2', '3']\n"
+            b"This is doit.py!\nMy args are ['doit.py', '1', '2', '3']\n"
         )
 
     def test_executing_extra_files(self):
         res = jailpy(
             extra_files=[
-                ("run.py", textwrap.dedent("""\
+                ("run.py", bytes(textwrap.dedent("""\
+                            from __future__ import print_function
                             import os
-                            print sorted(os.listdir('.'))
-                            print open('also.txt').read()
-                            """)),
+                            print(sorted(os.listdir('.')))
+                            print(open('also.txt', 'rb').read())
+                            """), 'utf8')),
                 # This file has some non-ASCII, non-UTF8, just binary data.
-                ("also.txt", "also here\xff\x00\xab"),
+                ("also.txt", b"also here\xff\x00\xab"),
             ],
             argv=["run.py"],
         )
         self.assertResultOk(res)
-        self.assertEqual(
-            res.stdout,
-            "['also.txt', 'run.py', 'tmp']\nalso here\xff\x00\xab\n"
-        )
+        if six.PY2:
+            self.assertEqual(
+                res.stdout,
+                b"['also.txt', 'run.py', 'tmp']\nalso here\xff\x00\xab\n"
+            )
+        else:
+            self.assertEqual(
+                res.stdout,
+                b"['also.txt', 'run.py', 'tmp']\nb'also here\\xff\\x00\\xab'\n"
+            )
 
     def test_we_can_remove_tmp_files(self):
         # This test is meant to create a tmp file in a temp folder as the
@@ -209,6 +236,7 @@ class TestFeatures(JailCodeHelpers, unittest.TestCase):
         set_limit('FSIZE', 1000)
         res = jailpy(
             code="""\
+                from __future__ import print_function
                 import os, shutil, tempfile
                 temp_dir = tempfile.mkdtemp()
                 with open("{}/myfile.txt".format(temp_dir), "w") as f:
@@ -216,22 +244,27 @@ class TestFeatures(JailCodeHelpers, unittest.TestCase):
                 shutil.move("{}/myfile.txt".format(temp_dir),
                             "{}/overthere.txt".format(temp_dir))
                 with open("{}/overthere.txt".format(temp_dir)) as f:
-                    print f.read()
+                    print(f.read())
                 with open("{}/.myfile.txt".format(temp_dir), "w") as f:
                     f.write("This is my dot file!")
                 # Now make it secret!
                 os.chmod("{}/overthere.txt".format(temp_dir), 0)
-                print sorted(os.listdir(temp_dir))
+                print(sorted(os.listdir(temp_dir)))
             """)
         self.assertResultOk(res)
         self.assertEqual(
             res.stdout,
-            "This is my file!\n['.myfile.txt', 'overthere.txt']\n"
+            b"This is my file!\n['.myfile.txt', 'overthere.txt']\n"
         )
 
     @mock.patch("codejail.subproc.log._log")
     def test_slugs_get_logged(self, log_log):
-        res = jailpy(code="print 'Hello, world!'", slug="HELLO")
+        res = jailpy(
+            code="""
+                from __future__ import print_function; print('Hello, world!')
+            """,
+            slug="HELLO"
+        )
         log_text = text_of_logs(log_log.mock_calls)
         self.assertRegexpMatches(log_text, r"INFO: Executed jailed code HELLO in .*, with PID .*")
 
@@ -251,33 +284,54 @@ class TestLimits(JailCodeHelpers, unittest.TestCase):
     def test_cant_use_too_much_memory(self):
         # This will fail after setting the limit to 30Mb.
         set_limit('VMEM', 80000000)
-        res = jailpy(code="print len(bytearray(100000000))")
-        self.assertEqual(res.stdout, "")
-        self.assertIn("MemoryError", res.stderr)
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                print(len(bytearray(100000000)))
+            """
+        )
+        self.assertEqual(res.stdout, b"")
+        self.assertIn(b"MemoryError", res.stderr)
         self.assertEqual(res.status, 1)
 
     def test_changing_vmem_limit(self):
         # Up the limit, it will succeed.
         set_limit('VMEM', 160000000)
-        res = jailpy(code="print len(bytearray(100000000))")
-        self.assertEqual(res.stderr, "")
-        self.assertEqual(res.stdout, "100000000\n")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                print(len(bytearray(100000000)))
+            """
+        )
+        self.assertEqual(res.stderr, b"")
+        self.assertEqual(res.stdout, b"100000000\n")
         self.assertEqual(res.status, 0)
 
     def test_disabling_vmem_limit(self):
         # Disable the limit, it will succeed.
         set_limit('VMEM', 0)
-        res = jailpy(code="print len(bytearray(50000000))")
-        self.assertEqual(res.stderr, "")
-        self.assertEqual(res.stdout, "50000000\n")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                print(len(bytearray(50000000)))
+            """
+        )
+        self.assertEqual(res.stderr, b"")
+        self.assertEqual(res.stdout, b"50000000\n")
         self.assertEqual(res.status, 0)
 
     def test_cant_use_too_much_cpu(self):
         set_limit('CPU', 1)
         set_limit('REALTIME', 10)
-        res = jailpy(code="print sum(xrange(2**31-1))")
-        self.assertEqual(res.stdout, "")
-        self.assertEqual(res.stderr, "")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                from six.moves import range
+                print(sum(range(2**31-1)))
+            """
+        )
+        self.assertEqual(res.stdout, b"")
+        self.assertEqual(res.stderr, b"")
         self.assertEqual(res.status, -signal.SIGXCPU)    # 137
 
     @mock.patch("codejail.subproc.log._log")
@@ -285,8 +339,15 @@ class TestLimits(JailCodeHelpers, unittest.TestCase):
         # Default time limit is 1 second.  Sleep for 1.5 seconds.
         set_limit('CPU', 100)
         set_limit('REALTIME', 1)
-        res = jailpy(code="import time; time.sleep(1.5); print 'Done!'")
-        self.assertEqual(res.stdout, "")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                import time
+                time.sleep(1.5)
+                print('Done!')
+            """
+        )
+        self.assertEqual(res.stdout, b"")
         self.assertEqual(res.status, -signal.SIGKILL)       # -9
 
         # Make sure we log that we are killing the process.
@@ -296,62 +357,84 @@ class TestLimits(JailCodeHelpers, unittest.TestCase):
     def test_changing_realtime_limit(self):
         # Change time limit to 2 seconds, sleeping for 1.5 will be fine.
         set_limit('REALTIME', 2)
-        res = jailpy(code="import time; time.sleep(1.5); print 'Done!'")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                import time
+                time.sleep(1.5)
+                print('Done!')
+            """
+        )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "Done!\n")
+        self.assertEqual(res.stdout, b"Done!\n")
 
     def test_disabling_realtime_limit(self):
         # Disable the time limit, sleeping for 1.5 will be fine.
         set_limit('REALTIME', 0)
-        res = jailpy(code="import time; time.sleep(1.5); print 'Done!'")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                import time
+                time.sleep(1.5)
+                print('Done!')
+            """
+        )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "Done!\n")
+        self.assertEqual(res.stdout, b"Done!\n")
 
     def test_cant_write_files(self):
         res = jailpy(code="""\
-                print "Trying"
+                from __future__ import print_function
+                print("Trying")
                 with open("mydata.txt", "w") as f:
                     f.write("hello")
                 with open("mydata.txt") as f2:
-                    print "Got this:", f2.read()
+                    print("Got this:", f2.read())
                 """)
         self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "Trying\n")
-        self.assertIn("ermission denied", res.stderr)
+        self.assertEqual(res.stdout, b"Trying\n")
+        self.assertIn(b"ermission denied", res.stderr)
 
     def test_can_write_temp_files(self):
         set_limit('FSIZE', 1000)
         res = jailpy(code="""\
+                from __future__ import print_function
                 import os, tempfile
-                print "Trying mkstemp"
+                print("Trying mkstemp")
                 f, path = tempfile.mkstemp()
                 os.close(f)
                 with open(path, "w") as f1:
                     f1.write("hello")
                 with open(path) as f2:
-                    print "Got this:", f2.read()
+                    print("Got this:", f2.read())
                 """)
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "Trying mkstemp\nGot this: hello\n")
+        self.assertEqual(res.stdout, b"Trying mkstemp\nGot this: hello\n")
 
     def test_cant_write_large_temp_files(self):
         set_limit('FSIZE', 1000)
         res = jailpy(code="""\
+                from __future__ import print_function
                 import os, tempfile
-                print "Trying mkstemp"
+                from six.moves import range
+                print("Trying mkstemp")
                 f, path = tempfile.mkstemp()
                 os.close(f)
                 with open(path, "w") as f1:
                     try:
-                        f1.write(".".join("%05d" % i for i in xrange(1000)))
+                        f1.write(".".join("%05d" % i for i in range(1000)))
                     except IOError as e:
-                        print "Expected exception: %s" % e
+                        print("Expected exception: %s" % e)
                     else:
                         with open(path) as f2:
-                            print "Got this:", f2.read()
+                            print("Got this:", f2.read())
                 """)
-        self.assertResultOk(res)
-        self.assertIn("Expected exception", res.stdout)
+        if six.PY2:
+            self.assertResultOk(res)
+            self.assertIn(b"Expected exception", res.stdout)
+        else:
+            self.assertIn(b"OSError", res.stderr)
+            self.assertIn(b"File too large", res.stderr)
 
     def test_cant_write_many_small_temp_files(self):
         # We would like this to fail, but there's nothing that checks total
@@ -359,8 +442,9 @@ class TestLimits(JailCodeHelpers, unittest.TestCase):
         raise SkipTest("There's nothing checking total file size yet.")
         set_limit('FSIZE', 1000)
         res = jailpy(code="""\
+                from __future__ import print_function
                 import os, tempfile
-                print "Trying mkstemp 250"
+                print("Trying mkstemp 250")
                 for i in range(250):
                     f, path = tempfile.mkstemp()
                     os.close(f)
@@ -368,67 +452,102 @@ class TestLimits(JailCodeHelpers, unittest.TestCase):
                         f1.write("hello")
                     with open(path) as f2:
                         assert f2.read() == "hello"
-                print "Finished 250"
+                print("Finished 250")
                 """)
         self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "Trying mkstemp 250\n")
-        self.assertIn("IOError", res.stderr)
+        self.assertEqual(res.stdout, b"Trying mkstemp 250\n")
+        self.assertIn(b"IOError", res.stderr)
 
     def test_cant_use_network(self):
         res = jailpy(code="""\
-                import urllib
-                print "Reading google"
-                u = urllib.urlopen("http://google.com")
+                from __future__ import print_function
+                try:
+                    from urllib import urlopen
+                except ImportError:
+                    from urllib.request import urlopen
+                print("Reading google")
+                u = urlopen("http://google.com")
                 google = u.read()
-                print len(google)
+                print(len(google))
                 """)
         self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "Reading google\n")
-        self.assertIn("IOError", res.stderr)
+        self.assertEqual(res.stdout, b"Reading google\n")
+        if six.PY2:
+            self.assertIn(b"IOError", res.stderr)
+        else:
+            self.assertIn(b"URLError", res.stderr)
 
     def test_cant_use_raw_network(self):
         res = jailpy(code="""\
-                import urllib
-                print "Reading example.com"
-                u = urllib.urlopen("http://93.184.216.119")
+                from __future__ import print_function
+                try:
+                    from urllib import urlopen
+                except ImportError:
+                    from urllib.request import urlopen
+                print("Reading example.com")
+                u = urlopen("http://93.184.216.119")
                 example = u.read()
-                print len(example)
+                print(len(example))
                 """)
         self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "Reading example.com\n")
-        self.assertIn("IOError", res.stderr)
+        self.assertEqual(res.stdout, b"Reading example.com\n")
+        if six.PY2:
+            self.assertIn(b"IOError", res.stderr)
+        else:
+            self.assertIn(b"URLError", res.stderr)
 
     def test_cant_fork(self):
         set_limit('NPROC', 1)
-        res = jailpy(code="""\
+        res = jailpy(
+            code="""\
+                from __future__ import print_function
                 import os
-                print "Forking"
+                print("Forking")
                 child_ppid = os.fork()
-                print child_ppid
-                """)
+                print(child_ppid)
+            """
+        )
         # stdout should only contain the first print statement
-        self.assertEqual(res.stdout, "Forking\n")
-        self.assertIn("OSError", res.stderr)
+        self.assertEqual(res.stdout, b"Forking\n")
+        if six.PY2:
+            self.assertIn(b"OSError", res.stderr)
+        else:
+            self.assertIn(b'BlockingIOError', res.stderr)
         self.assertNotEqual(res.status, 0)
 
     def test_cant_see_environment_variables(self):
         os.environ['HONEY_BOO_BOO'] = 'Look!'
-        res = jailpy(code="""\
+        res = jailpy(
+            code="""\
+                from __future__ import print_function
                 import os
                 for name, value in os.environ.items():
-                    print "%s: %r" % (name, value)
-                """)
+                    print("%s: %r" % (name, value))
+            """
+        )
         self.assertResultOk(res)
-        self.assertNotIn("HONEY", res.stdout)
+        self.assertNotIn(b"HONEY", res.stdout)
 
     def test_reading_dev_random(self):
         # We can read 10 bytes just fine.
-        res = jailpy(code="x = open('/dev/urandom').read(10); print len(x)")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                x = open('/dev/urandom', 'rb').read(10)
+                print(len(x))
+            """
+        )
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "10\n")
+        self.assertEqual(res.stdout, b"10\n")
 
         # If we try to read all of it, we'll be killed by the real-time limit.
-        res = jailpy(code="x = open('/dev/urandom').read(); print 'Done!'")
+        res = jailpy(
+            code="""
+                from __future__ import print_function
+                x = open('/dev/urandom', 'rb').read()
+                print('Done!')
+            """
+        )
         self.assertNotEqual(res.status, 0)
 
 
@@ -464,27 +583,29 @@ class TestSymlinks(JailCodeHelpers, unittest.TestCase):
         # the symlink.
         res = jailpy(
             code="""\
-                print open('copied/here.txt').read()        # can read
-                print open('copied/herelink.txt').read()    # can read
-                print open('copied/link.txt').read()        # can't read
+                from __future__ import print_function
+                print(open('copied/here.txt').read())        # can read
+                print(open('copied/herelink.txt').read())    # can read
+                print(open('copied/link.txt').read())        # can't read
                 """,
             files=[self.copied],
         )
-        self.assertEqual(res.stdout, "012345\n012345\n")
-        self.assertIn("ermission denied", res.stderr)
+        self.assertEqual(res.stdout, b"012345\n012345\n")
+        self.assertIn(b"ermission denied", res.stderr)
 
     def test_symlinks_wont_copy_data(self):
         # Run some code in the sandbox, with a copied file which is a symlink.
         res = jailpy(
             code="""\
-                print open('here.txt').read()       # can read
-                print open('herelink.txt').read()   # can read
-                print open('link.txt').read()       # can't read
+                from __future__ import print_function
+                print(open('here.txt').read())       # can read
+                print(open('herelink.txt').read())   # can read
+                print(open('link.txt').read())       # can't read
                 """,
             files=[self.here_txt, self.herelink_txt, self.link_txt],
         )
-        self.assertEqual(res.stdout, "012345\n012345\n")
-        self.assertIn("ermission denied", res.stderr)
+        self.assertEqual(res.stdout, b"012345\n012345\n")
+        self.assertIn(b"ermission denied", res.stderr)
 
 
 class TestMalware(JailCodeHelpers, unittest.TestCase):
@@ -492,30 +613,39 @@ class TestMalware(JailCodeHelpers, unittest.TestCase):
 
     def test_crash_cpython(self):
         # http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
+
+        # the `new` module has been removed in Python 3, and replaced with the
+        # `types` module. This test code needs to be refactored to support
+        # both.
+        if six.PY3:
+            raise SkipTest('Not supported in Python 3 yet')
         res = jailpy(code="""\
+            from __future__ import print_function
             import new, sys
             bad_code = new.code(0,0,0,0,"KABOOM",(),(),(),"","",0,"")
             crash_me = new.function(bad_code, {})
-            print "Here we go..."
+            print("Here we go...")
             sys.stdout.flush()
             crash_me()
-            print "The afterlife!"
+            print("The afterlife!")
             """)
         self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "Here we go...\n")
-        self.assertEqual(res.stderr, "")
+        self.assertEqual(res.stderr, b"")
+        self.assertEqual(res.stdout, b"Here we go...\n")
 
     def test_read_etc_passwd(self):
         res = jailpy(code="""\
+            from __future__ import print_function
             bytes = len(open('/etc/passwd').read())
-            print 'Gotcha', bytes
+            print('Gotcha', bytes)
             """)
         self.assertNotEqual(res.status, 0)
-        self.assertEqual(res.stdout, "")
-        self.assertIn("ermission denied", res.stderr)
+        self.assertEqual(res.stdout, b"")
+        self.assertIn(b"ermission denied", res.stderr)
 
     def test_find_other_sandboxes(self):
         res = jailpy(code="""
+            from __future__ import print_function
             import os
             places = [
                 "..", "/tmp", "/", "/home", "/etc", "/var"
@@ -527,11 +657,11 @@ class TestMalware(JailCodeHelpers, unittest.TestCase):
                     # darn
                     pass
                 else:
-                    print "Files in %r: %r" % (place, files)
-            print "Done."
+                    print("Files in %r: %r" % (place, files))
+            print("Done.")
             """)
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, "Done.\n")
+        self.assertEqual(res.stdout, b"Done.\n")
 
 
 class TestProxyProcess(JailCodeHelpers, unittest.TestCase):
@@ -548,9 +678,9 @@ class TestProxyProcess(JailCodeHelpers, unittest.TestCase):
     def run_ok(self):
         """Run some code to see that it works."""
         num = int(time.time()*100000)
-        res = jailpy(code="print 'Look: %d'" % num)
+        res = jailpy(code="from __future__ import print_function; print('Look: %d')" % num)
         self.assertResultOk(res)
-        self.assertEqual(res.stdout, 'Look: %d\n' % num)
+        self.assertEqual(res.stdout, b'Look: %d\n' % num)
 
     def test_proxy_is_persistent(self):
         # Running code twice, you use the same proxy process.

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,18 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="0.1",
+    version="2.0",
     packages=['codejail'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Ubuntu",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 2.7",
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
This gets the tests passing in python3.

There are a couple of things to note here:
* Most of the fixes are modernizing the code strings in the tests themselves and a lot of conversions due to the changes in bytes/strings in python 3.
* Some exceptions changed from 2 to 3, so now you need to check the python version in the test.
* I had to `skip test_crash_cpython` for now, as it needs some rethinking with regards of how to get it to work in Python 3
* we shifted the main dev branch from `edx-platform-master` to `master`, which broke datree's brain, so you can probably disregard the failure.