### PR TITLE
Improve Serialization Logic

### DIFF
--- a/codejail/safe_exec.py
+++ b/codejail/safe_exec.py
@@ -22,7 +22,7 @@ log = logging.getLogger("codejail")
 # Flags to let developers temporarily change some behavior in this file.
 
 # Set this to True to log all the code and globals being executed.
-LOG_ALL_CODE = True
+LOG_ALL_CODE = False
 # Set this to True to use the unsafe code, so that you can debug it.
 ALWAYS_BE_UNSAFE = False
 
@@ -155,9 +155,10 @@ def safe_exec(code, globals_dict, files=None, python_path=None, slug=None,
                 new_dict = {}
                 for k,v in six.iteritems(obj):
                     try:
+                        new_key = filter_unserializable(k)
                         new_value = filter_unserializable(v)
-                        if jsonable(new_value):
-                            new_dict[k] = new_value
+                        if jsonable(new_value) and jsonable(new_key):
+                            new_dict[new_key] = new_value
                     except Exception as e:
                         pass # Don't add the item if we can't decode it
                 return new_dict
@@ -248,9 +249,10 @@ def json_safe(d):
             new_dict = {}
             for k,v in six.iteritems(obj):
                 try:
+                    new_key = filter_unserializable(k)
                     new_value = filter_unserializable(v)
-                    if jsonable(new_value):
-                        new_dict[k] = new_value
+                    if jsonable(new_value) and jsonable(new_key):
+                        new_dict[new_key] = new_value
                 except Exception:
                     pass # Don't add the item if we can't decode it
             return new_dict
@@ -268,7 +270,6 @@ def json_safe(d):
             return obj
 
     serializable_dict = filter_unserializable(d)
-    #serializable_dict = d
 
     bad_keys = ("__builtins__",)
     jd = {}

--- a/codejail/tests/test_safe_exec.py
+++ b/codejail/tests/test_safe_exec.py
@@ -53,8 +53,6 @@ class SafeExecTests(unittest.TestCase):
             """),
             globs
         )
-        from pprint import pprint
-        pprint(globs)
         self.assertDictEqual(globs['test_dict'], {'1': 'a', '2': 'b', '3': {'1': 'b', '2': [1, 'a']}})
 
     def test_files_are_copied(self):

--- a/codejail/tests/test_safe_exec.py
+++ b/codejail/tests/test_safe_exec.py
@@ -45,9 +45,16 @@ class SafeExecTests(unittest.TestCase):
     def test_complex_globals(self):
         globs = {}
         self.safe_exec(
-            "from builtins import bytes; test_dict = {1: bytes('a', 'utf8'), 2: 'b', 3: {1: bytes('b', 'utf8'), 2: (1, bytes('a', 'utf8'))}}",
+            textwrap.dedent("""\
+            from builtins import bytes
+            test_dict = {1: bytes('a', 'utf8'), 2: 'b', 3: {1: bytes('b', 'utf8'), 2: (1, bytes('a', 'utf8'))}}
+            foo = "bar"
+            test_dict_type = type(test_dict)
+            """),
             globs
         )
+        from pprint import pprint
+        pprint(globs)
         self.assertDictEqual(globs['test_dict'], {'1': 'a', '2': 'b', '3': {'1': 'b', '2': [1, 'a']}})
 
     def test_files_are_copied(self):
@@ -113,7 +120,8 @@ class SafeExecTests(unittest.TestCase):
         ]
         self.safe_exec(textwrap.dedent("""\
             import six
-            with open("extra.txt", 'rb') as f:
+            import io
+            with io.open("extra.txt", 'r') as f:
                 extra = f.read()
             with open("also.dat", 'rb') as f:
                 if six.PY2:
@@ -121,6 +129,7 @@ class SafeExecTests(unittest.TestCase):
                 else:
                     also = f.read().hex()
             """), globs, extra_files=extras)
+
         self.assertEqual(globs['extra'], "I'm extra!\n")
         self.assertEqual(globs['also'], "01ff02fe")
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="2.0",
+    version="2.1",
     packages=['codejail'],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
As a part of the python3 conversion, we added logic to try to convert
bytestrings to unicode strings.  This had a problem because not all
bytestrings that are produced as a part of the context passed into and
out of the jailed code execution is actually unicode strings.  In some
cases this was resulting in a unicode decode error.

Before this code existed we used to just drop any nonstandard types and
also only keep complex types(list,dict,tuples) that were easily
jsonable.  In python2 this was fine because byte strings would
automatically get coerced to unicode strings.  However in python3 this
will throw errors.  So if we don't explicitly try to convert all the
byte strings to unicode, we could stop passing back data that we
previously used to pass in.

The first iteration of this code assumed all byte arrays were unicode
strings.  From evidence in production this is not always the case.  So
we fall back to the behaviour we had before this change where if an item
can't successfully be converted to something we can serialize to json,
we just drop that item from the list of content being passed back
through the serialization straw.