### PR TITLE
[BD-6] Add py38 to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py{35,38}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Add py38 to tox.ini so we can run python 3.8 tests in jenkins.

Related to https://openedx.atlassian.net/browse/BOM-1591

I think that we need an additional step in the jenkins configuration

## Reviewers
- [ ] @awais786 
- [ ] Ready for edX review.