### PR TITLE
[BD-6] Fix check of virtualenv for virtualenv<20.0.0

### DIFF
--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -62,9 +62,11 @@ def is_configured(command):
 
 # By default, look where our current Python is, and maybe there's a
 # python-sandbox alongside.  Only do this if running in a virtualenv.
-real_prefix = getattr(sys, "real_prefix", None)
-base_prefix = getattr(sys, "base_prefix", sys.prefix)
-running_in_virtualenv = (base_prefix or real_prefix) != sys.prefix
+# The check for sys.real_prefix covers virtualenv
+# the equality of non-empty sys.base_prefix with sys.prefix covers venv
+running_in_virtualenv = (hasattr(sys, 'real_prefix') or
+    (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))
+
 if running_in_virtualenv:
     # On jenkins
     sandbox_user = os.getenv('CODEJAIL_TEST_USER')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="3.0.0",
+    version="3.0.1",
     packages=['codejail'],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Change the way to check if it is running in a virtualenv in order to be compatible with virtualenv>20.0.0 and virtualenv<20.0.0 (currently used in the platform)

I separated the change in three commits, so you can see that
1- in the first commit (using virtualenv<20.0.0) it is failing,
2- In the second commit, the changes fixed the problem for virtualenv<20.0.0
3- in the third commit we are using again virtualenv>20.0.0 and it is working

## Reviewers
 - [ ] @feanil 