### PR TITLE
Add required dependency on "six" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="3.0.1",
+    version="3.0.2",
     packages=['codejail'],
+    install_requires=['six'],
     zip_safe=False,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Currently, setup.py yields a non-working installation if the "six" package is not already installed. This PR adds "six" to install_requires so installations in minimal environments work out the box.