### PR TITLE
Allow context-specific resource limits to be provided

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,0 @@
-Ned Batchelder <ned@nedbatchelder.com>
-Will Daly <will@edx.org>
-Brian Wilson <brian@edx.org>
-Julia Hansbrough <julia@edx.org>
-James Tauber <jtauber@jtauber.com>
-Piotr Mitros <pmitros@edx.org>
-Feanil Patel <feanil@edx.org>
-Dave St.Germain <dstgermain@edx.org>

--- a/codejail/django_integration.py
+++ b/codejail/django_integration.py
@@ -4,12 +4,11 @@ Code to glue codejail into a Django environment.
 
 """
 
-from __future__ import absolute_import
 from django.core.exceptions import MiddlewareNotUsed
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
-import codejail.jail_code
+from . import django_integration_utils
 
 
 class ConfigureCodeJailMiddleware(MiddlewareMixin):
@@ -19,18 +18,8 @@ class ConfigureCodeJailMiddleware(MiddlewareMixin):
     This is a Django idiom to have code run once on server startup: put the
     code in the `__init__` of some middleware, and have it do the work, then
     raise `MiddlewareNotUsed` to disable the middleware.
-
     """
     def __init__(self, *args, **kwargs):
-        python_bin = settings.CODE_JAIL.get('python_bin')
-        if python_bin:
-            user = settings.CODE_JAIL['user']
-            codejail.jail_code.configure("python", python_bin, user=user)
-
-        limits = settings.CODE_JAIL.get('limits', {})
-        for name, value in limits.items():
-            codejail.jail_code.set_limit(name, value)
-
+        django_integration_utils.apply_django_settings(settings.CODE_JAIL)
         super(ConfigureCodeJailMiddleware, self).__init__(*args, **kwargs)
-
         raise MiddlewareNotUsed

--- a/codejail/django_integration_utils.py
+++ b/codejail/django_integration_utils.py
@@ -1,0 +1,31 @@
+"""
+Utility functions to support Django integration for codejail.
+
+Split out from `django_integration` to allow testing without installing Django.
+"""
+
+from . import jail_code
+
+
+def apply_django_settings(code_jail_settings):
+    """
+    Apply a settings.CODE_JAIL dictionary to the `jail_code` module.
+    """
+    python_bin = code_jail_settings.get('python_bin')
+    if python_bin:
+        user = code_jail_settings['user']
+        jail_code.configure("python", python_bin, user=user)
+    limits = code_jail_settings.get('limits', {})
+    for name, value in limits.items():
+        jail_code.set_limit(
+            limit_name=name,
+            value=value,
+        )
+    limit_overrides = code_jail_settings.get('limit_overrides', {})
+    for context, overrides in limit_overrides.items():
+        for name, value in overrides.items():
+            jail_code.override_limit(
+                limit_name=name,
+                value=value,
+                limit_overrides_context=context,
+            )

--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -78,9 +78,8 @@ if running_in_virtualenv:
         configure("python", sys.prefix + "-sandbox/bin/python", "sandbox")
 
 
-# Configurable limits
-
-LIMITS = {
+# The resource limits that we unless otherwise configured.
+DEFAULT_LIMITS = {
     # CPU seconds, defaulting to 1.
     "CPU": 1,
     # Real time, defaulting to 1 second.
@@ -97,7 +96,12 @@ LIMITS = {
     "PROXY": None,
 }
 
+# Configured resource limits.
+# Modified by calling `set_limit`.
+LIMITS = DEFAULT_LIMITS.copy()
+
 # Map from limit_overrides_contexts (strings) to dictionaries in the shape of LIMITS.
+# Modified by calling `override_limit`.
 LIMIT_OVERRIDES = {}
 
 

--- a/codejail/safe_exec.py
+++ b/codejail/safe_exec.py
@@ -39,8 +39,8 @@ class SafeExecException(Exception):
     pass
 
 
-def safe_exec(code, globals_dict, files=None, python_path=None, slug=None,
-              extra_files=None):
+def safe_exec(code, globals_dict, files=None, python_path=None,
+              limit_overrides_context=None, slug=None, extra_files=None):
     """
     Execute code as "exec" does, but safely.
 
@@ -57,6 +57,10 @@ def safe_exec(code, globals_dict, files=None, python_path=None, slug=None,
     added to `sys.path` so that modules they contain can be imported.  Only
     directories and zip files are supported.  If the name is not provided in
     `extras_files`, it will be copied just as if it had been listed in `files`.
+
+    `limit_overrides_context` is an optional string to use as a key against the
+    configured limit overrides contexts. If omitted or if no such limit override context
+    has been configured, then use the default limits.
 
     `slug` is an arbitrary string, a description that's meaningful to the
     caller, that will be used in log messages.
@@ -141,8 +145,9 @@ def safe_exec(code, globals_dict, files=None, python_path=None, slug=None,
         log.debug("Stdin: %s", stdin)
 
     res = jail_code.jail_code(
-        "python", code=jailed_code, stdin=stdin, files=files, slug=slug,
-        extra_files=extra_files,
+        "python", code=jailed_code, stdin=stdin, files=files,
+        limit_overrides_context=limit_overrides_context,
+        slug=slug, extra_files=extra_files,
     )
 
     if LOG_ALL_CODE:
@@ -225,8 +230,9 @@ def json_safe(d):
     return json.loads(json.dumps(jd))
 
 
-def not_safe_exec(code, globals_dict, files=None, python_path=None, slug=None,
-                  extra_files=None):
+def not_safe_exec(code, globals_dict, files=None, python_path=None,
+                  limit_overrides_context=None,  # pylint: disable=unused-argument
+                  slug=None, extra_files=None):
     """
     Another implementation of `safe_exec`, but not safe.
 
@@ -235,6 +241,8 @@ def not_safe_exec(code, globals_dict, files=None, python_path=None, slug=None,
     This is not thread-safe, due to temporarily changing the current directory
     and modifying sys.path.
 
+    Note that `limit_overrides_context` is ignored here, because resource limits
+    are not applied.
     """
     g_dict = json_safe(globals_dict)
 

--- a/codejail/tests/test_django_integration_utils.py
+++ b/codejail/tests/test_django_integration_utils.py
@@ -1,0 +1,167 @@
+"""Test django_integration_utils.py"""
+
+from unittest import TestCase
+
+from .. import jail_code
+from ..django_integration_utils import apply_django_settings
+
+
+class ApplyDjangoSettingsTest(TestCase):
+    """
+    Test `apply_settings_from_django` function.
+    """
+
+    def setUp(self):
+        """
+        Copy the global variables that we modify.
+        """
+        super().setUp()
+        # pylint: disable=invalid-name
+        self._COMMANDS = jail_code.COMMANDS.copy()
+        self._LIMITS = jail_code.LIMITS.copy()
+        self._LIMIT_OVERRIDES = jail_code.LIMIT_OVERRIDES.copy()
+
+    def tearDown(self):
+        """
+        Restore the copied global variables.
+        """
+        super().setUp()
+        jail_code.COMMANDS = self._COMMANDS
+        jail_code.LIMITS = self._LIMITS
+        jail_code.LIMIT_OVERRIDES = self._LIMIT_OVERRIDES
+
+    def test_not_configured(self):
+        """
+        Test that conditions are sane if `apply_settings_from_django` is not run at all.
+        """
+        # No Python configuration.
+        assert not jail_code.is_configured('python')
+
+        # There are global limits.
+        assert jail_code.LIMITS
+
+        # No overrides, so the effective limits are the same as the global limits.
+        assert jail_code.get_effective_limits() == jail_code.LIMITS
+
+    def test_empty_config(self):
+        """
+        Test that conditions are sane if `apply_settings_from_django` receives an empty dict.
+        """
+        apply_django_settings({})
+
+        # No Python configuration.
+        assert not jail_code.is_configured('python')
+
+        # There are global limits.
+        assert jail_code.LIMITS
+
+        # No overrides, so the effective limits are the same as the global limits.
+        assert jail_code.get_effective_limits() == jail_code.LIMITS
+
+    def test_command_config(self):
+        """
+        Test that Python path and user can be configured.
+        """
+        apply_django_settings({
+            'python_bin': '/a/b/c/bin/python',
+            'user': 'python_executor',
+        })
+        assert (
+            jail_code.COMMANDS['python'] ==
+            {
+                'cmdline_start': ['/a/b/c/bin/python', '-E', '-B'],
+                'user': 'python_executor',
+            }
+        )
+
+    def test_limits_config(self):
+        """
+        Test that limits can be configured.
+        """
+        apply_django_settings({
+            'limits': {
+                'CPU': 5,
+                "REALTIME": 7,
+                'VMEM': 123456789,
+                'PROXY': 1,
+            },
+        })
+        assert (
+            jail_code.get_effective_limits() ==
+            {
+                'CPU': 5,
+                'REALTIME': 7,
+                'VMEM': 123456789,
+                'FSIZE': 0,
+                'NPROC': 15,
+                'PROXY': 1,
+            }
+        )
+
+    def test_limits_with_overrides_config(self):
+        """
+        Test that limits can be configured and (besides PROXY) be overriden.
+        """
+        apply_django_settings({
+            'limits': {
+                'CPU': 5,
+                "REALTIME": 7,
+                'VMEM': 123456789,
+                'PROXY': 1,
+            },
+            'limit_overrides': {
+                'course-v1:a+b+c': {
+                    'CPU': 50,
+                    'FSIZE': 88,
+                },
+                'pathway-v1:x+y+z': {
+                    'VMEM': 987654321,
+                    'PROXY': 0,  # This override should not work.
+                },
+            },
+        })
+
+        # Global limits still apply.
+        assert (
+            jail_code.get_effective_limits() ==
+            {
+                'CPU': 5,
+                'REALTIME': 7,
+                'VMEM': 123456789,
+                'FSIZE': 0,
+                'NPROC': 15,
+                'PROXY': 1,
+            }
+        )
+
+        # Context without configured overrides just uses global limits.
+        assert (
+            jail_code.get_effective_limits() ==
+            jail_code.get_effective_limits('arbitrary-context')
+        )
+
+        # CPU and FSIZE are overriden.
+        assert (
+            jail_code.get_effective_limits('course-v1:a+b+c') ==
+            {
+                'CPU': 50,
+                'REALTIME': 7,
+                'VMEM': 123456789,
+                'FSIZE': 88,
+                'NPROC': 15,
+                'PROXY': 1,
+            }
+        )
+
+        # VMEM is overriden, but PROXY override is ignored.
+        assert (
+            jail_code.get_effective_limits('pathway-v1:x+y+z') ==
+            {
+                'CPU': 5,
+                'REALTIME': 7,
+                'VMEM': 987654321,
+                'FSIZE': 0,
+                'NPROC': 15,
+                'PROXY': 1,
+            }
+        )

--- a/codejail/tests/test_django_integration_utils.py
+++ b/codejail/tests/test_django_integration_utils.py
@@ -5,30 +5,13 @@ from unittest import TestCase
 from .. import jail_code
 from ..django_integration_utils import apply_django_settings
 
+from .util import ResetJailCodeStateMixin
 
-class ApplyDjangoSettingsTest(TestCase):
+
+class ApplyDjangoSettingsTest(ResetJailCodeStateMixin, TestCase):
     """
     Test `apply_settings_from_django` function.
     """
-
-    def setUp(self):
-        """
-        Copy the global variables that we modify.
-        """
-        super().setUp()
-        # pylint: disable=invalid-name
-        self._COMMANDS = jail_code.COMMANDS.copy()
-        self._LIMITS = jail_code.LIMITS.copy()
-        self._LIMIT_OVERRIDES = jail_code.LIMIT_OVERRIDES.copy()
-
-    def tearDown(self):
-        """
-        Restore the copied global variables.
-        """
-        super().setUp()
-        jail_code.COMMANDS = self._COMMANDS
-        jail_code.LIMITS = self._LIMITS
-        jail_code.LIMIT_OVERRIDES = self._LIMIT_OVERRIDES
 
     def test_not_configured(self):
         """

--- a/codejail/tests/util.py
+++ b/codejail/tests/util.py
@@ -1,0 +1,36 @@
+"""
+Shared utilities for codejail tests.
+"""
+
+from .. import jail_code
+
+
+class ResetJailCodeStateMixin:
+    """
+    The jail_code module has global state.
+
+    Use this mixin to reset jail_code to its initial state before running a test function,
+    and then restore the existing state once the test function is complete.
+    """
+
+    def setUp(self):
+        """
+        Reset global variables back to defaults, copying and saving existing values.
+        """
+        super().setUp()
+        # pylint: disable=invalid-name
+        self._COMMANDS = jail_code.COMMANDS
+        self._LIMITS = jail_code.LIMITS
+        self._LIMIT_OVERRIDES = jail_code.LIMIT_OVERRIDES
+        jail_code.COMMANDS = {}
+        jail_code.LIMITS = jail_code.DEFAULT_LIMITS.copy()
+        jail_code.LIMIT_OVERRIDES = {}
+
+    def tearDown(self):
+        """
+        Restore global variables to the values they had before running the test.
+        """
+        super().setUp()
+        jail_code.COMMANDS = self._COMMANDS
+        jail_code.LIMITS = self._LIMITS
+        jail_code.LIMIT_OVERRIDES = self._LIMIT_OVERRIDES

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="3.0.2",
+    version="3.1.0",
     packages=['codejail'],
     install_requires=['six'],
     zip_safe=False,


### PR DESCRIPTION
We allow `limit_overrides_context` to be passed in to `jail_code`.

If `settings.CODE_JAIL['limit_overrides'][limit_overrides_context]` exists, then prefer those values to the ones in `settings.CODE_JAIL['limits']`.

In the [edx-platform PR](https://github.com/edx/edx-platform/pull/25483), we pass in the course run id is as the `limit_overrides_context`.

Per @nedbat 's comment, the PROXY setting cannot be overridden. An error will be logged and the override will be ignored.

(also, this removes outdated AUTHORS file, as we've done with most other repos)

### Links
* Customer request for root cause (codejail times out sometimes): https://openedx.atlassian.net/browse/CR-2519
* Customer request for a workaround for a specific course run: https://openedx.atlassian.net/browse/CR-2862
* TNL ticket for workaround: https://openedx.atlassian.net/browse/TNL-7649
* edx-platform change (requires this): https://github.com/edx/edx-platform/pull/25483
* Add limit overrides for specific course run: https://github.com/edx/edx-internal/pull/3562