### PR TITLE
Log effective resource limits for every jail_code call; also, fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 # Makefile for CodeJail
+.PHONY: clean dev-requirements quality requirements test test_no_proxy \
+        test_proxy upgrade upgrade
 
 clean:
 	find codejail -name '*.pyc' -exec rm -f {} +
@@ -24,8 +26,18 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/tox.txt requirements/tox.in
 	pip-compile --upgrade -o requirements/testing.txt requirements/testing.in
 	pip-compile --upgrade -o requirements/sandbox.txt requirements/sandbox.in
+	pip-compile --upgrade -o requirements/development.txt requirements/development.in
 
 quality: ## check coding style with pycodestyle and pylint
 	pycodestyle codejail *.py
 	isort --check-only --diff --recursive codejail *.py
 	pylint codejail *.py
+
+isort: ## apply automatic import sorting
+	isort --recursive codejail *.py
+
+requirements: dev-requirements
+
+dev-requirements:
+	pip install -r requirements/sandbox.txt
+	pip install -r requirements/development.txt

--- a/codejail/django_integration.py
+++ b/codejail/django_integration.py
@@ -4,8 +4,6 @@ Code to glue codejail into a Django environment.
 
 """
 
-# pylint: skip-file
-
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.utils.deprecation import MiddlewareMixin
@@ -23,5 +21,5 @@ class ConfigureCodeJailMiddleware(MiddlewareMixin):
     """
     def __init__(self, *args, **kwargs):
         django_integration_utils.apply_django_settings(settings.CODE_JAIL)
-        super(ConfigureCodeJailMiddleware, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         raise MiddlewareNotUsed

--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -227,6 +227,8 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
         .status: exit status of the process: an int, 0 for success
 
     """
+    # pylint: disable=too-many-statements
+
     if not is_configured(command):
         raise Exception("jail_code needs to be configured for %r" % command)
 
@@ -290,6 +292,11 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
 
         # Determine effective resource limits.
         effective_limits = get_effective_limits(limit_overrides_context)
+        log.info(
+            "Preparing to execute jailed code %s with resource limits: %r",
+            jail_code,
+            effective_limits,
+        )
 
         # Use the configuration and maybe an environment variable to determine
         # whether to use a proxy process.

--- a/codejail/proxy.py
+++ b/codejail/proxy.py
@@ -151,7 +151,7 @@ class CapturingHandler(logging.Handler):
     # pylint: disable=abstract-method
 
     def __init__(self):
-        super(CapturingHandler, self).__init__()
+        super().__init__()
         self.log_calls = []
 
     def createLock(self):

--- a/codejail/safe_exec.py
+++ b/codejail/safe_exec.py
@@ -281,7 +281,7 @@ def not_safe_exec(
                 # try here to include the traceback, since this is just a
                 # substitute implementation.
                 msg = "{0.__class__.__name__}: {0!s}".format(e)
-                raise SafeExecException(msg)
+                raise SafeExecException(msg)  # pylint: disable=raise-missing-from
             finally:
                 sys.path = original_path
 

--- a/codejail/subproc.py
+++ b/codejail/subproc.py
@@ -71,7 +71,7 @@ class ProcessKillerThread(threading.Thread):
     A thread to kill a process after a given time limit.
     """
     def __init__(self, subproc, limit):
-        super(ProcessKillerThread, self).__init__()
+        super().__init__()
         self.subproc = subproc
         self.limit = limit
 

--- a/codejail/tests/test_jail_code.py
+++ b/codejail/tests/test_jail_code.py
@@ -9,9 +9,8 @@ import tempfile
 import textwrap
 import time
 from builtins import bytes
-from unittest import SkipTest, TestCase
+from unittest import SkipTest, TestCase, mock
 
-import mock
 import six
 from six.moves import range
 
@@ -55,7 +54,7 @@ def text_of_logs(mock_calls):
 class JailCodeHelpersMixin:
     """Assert helpers for jail_code tests."""
     def setUp(self):
-        super(JailCodeHelpersMixin, self).setUp()
+        super().setUp()
         if not is_configured("python"):
             raise SkipTest
 
@@ -269,13 +268,13 @@ class TestLimits(JailCodeHelpersMixin, TestCase):
     """Tests of the resource limits, and changing them."""
 
     def setUp(self):
-        super(TestLimits, self).setUp()
+        super().setUp()
         self.old_limits = dict(LIMITS)
 
     def tearDown(self):
         for name, value in self.old_limits.items():
             set_limit(name, value)
-        super(TestLimits, self).tearDown()
+        super().tearDown()
 
     def test_cant_use_too_much_memory(self):
         # This will fail after setting the limit to 30Mb.
@@ -670,7 +669,7 @@ class TestProxyProcess(JailCodeHelpersMixin, TestCase):
         if not int(os.environ.get("CODEJAIL_PROXY", "0")):
             raise SkipTest()
 
-        super(TestProxyProcess, self).setUp()
+        super().setUp()
 
     def run_ok(self):
         """Run some code to see that it works."""

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -4,4 +4,22 @@
 #
 #    make upgrade
 #
-modernize==0.7
+appdirs==1.4.4            # via fissix
+astroid==2.4.2            # via -r requirements/testing.txt, pylint
+attrs==20.2.0             # via -r requirements/testing.txt, pytest
+fissix==20.8.0            # via modernize
+iniconfig==1.1.1          # via -r requirements/testing.txt, pytest
+isort==4.3.21             # via -r requirements/testing.txt, pylint
+lazy-object-proxy==1.4.3  # via -r requirements/testing.txt, astroid
+mccabe==0.6.1             # via -r requirements/testing.txt, pylint
+modernize==0.8.0          # via -r requirements/development.in
+packaging==20.4           # via -r requirements/testing.txt, pytest
+pluggy==0.13.1            # via -r requirements/testing.txt, pytest
+py==1.9.0                 # via -r requirements/testing.txt, pytest
+pycodestyle==2.6.0        # via -r requirements/testing.txt
+pylint==2.6.0             # via -r requirements/testing.txt
+pyparsing==2.4.7          # via -r requirements/testing.txt, packaging
+pytest==6.1.2             # via -r requirements/testing.txt
+six==1.15.0               # via -r requirements/testing.txt, astroid, packaging
+toml==0.10.2              # via -r requirements/testing.txt, pylint, pytest
+wrapt==1.12.1             # via -r requirements/testing.txt, astroid

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.2.1          # via -r requirements/pip_tools.in
+pip-tools==5.3.1          # via -r requirements/pip_tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/sandbox.txt
+++ b/requirements/sandbox.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-django==2.2.14            # via -c requirements/constraints.txt, -r requirements/sandbox.in
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/sandbox.in
 future==0.18.2            # via -r requirements/sandbox.in
-numpy==1.18.5             # via -r requirements/sandbox.in
-pytz==2020.1              # via django
+numpy==1.19.4             # via -r requirements/sandbox.in
+pytz==2020.4              # via django
 six==1.15.0               # via -r requirements/sandbox.in
-sqlparse==0.3.1           # via django
+sqlparse==0.4.1           # via django

--- a/requirements/testing.in
+++ b/requirements/testing.in
@@ -1,5 +1,6 @@
 -c constraints.txt
 
-mock
 pylint
 pytest
+isort<5  # Constraint for consistency. Most repos use isort==4.x for edx_lint compatibility.
+pycodestyle

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,23 +5,18 @@
 #    make upgrade
 #
 astroid==2.4.2            # via pylint
-attrs==19.3.0             # via pytest
-importlib-metadata==1.7.0  # via pluggy, pytest
-isort==4.3.21             # via pylint
+attrs==20.2.0             # via pytest
+iniconfig==1.1.1          # via pytest
+isort==4.3.21             # via -r requirements/testing.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -r requirements/testing.in
-more-itertools==8.4.0     # via pytest
 packaging==20.4           # via pytest
-pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
-pylint==2.5.3             # via -r requirements/testing.in
+pycodestyle==2.6.0        # via -r requirements/testing.in
+pylint==2.6.0             # via -r requirements/testing.in
 pyparsing==2.4.7          # via packaging
-pytest==5.4.3             # via -r requirements/testing.in
-six==1.15.0               # via astroid, mock, packaging, pathlib2
-toml==0.10.1              # via pylint
-typed-ast==1.4.1          # via astroid
-wcwidth==0.2.5            # via pytest
+pytest==6.1.2             # via -r requirements/testing.in
+six==1.15.0               # via astroid, packaging
+toml==0.10.2              # via pylint, pytest
 wrapt==1.12.1             # via astroid
-zipp==1.2.0               # via importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -7,14 +7,11 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
-toml==0.10.1              # via tox
-tox==3.16.1               # via -r requirements/tox.in
-virtualenv==20.0.26       # via tox
-zipp==1.2.0               # via importlib-metadata, importlib-resources
+toml==0.10.2              # via tox
+tox==3.20.1               # via -r requirements/tox.in
+virtualenv==20.1.0        # via tox

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="3.1.0",
+    version="3.1.1",
     packages=['codejail'],
     install_requires=['six'],
     zip_safe=False,


### PR DESCRIPTION
```
We are curious whether async jail_code calls on Celery workers
have different resource limit configurations than synchronous
calls on LMS/Studio. We suspect it may be different
because codejail is configured via a Django Middleware, which
may not be initialized for Celery workers.
```
https://github.com/edx/edx-platform/pull/25532
https://openedx.atlassian.net/browse/TNL-7649
https://openedx.atlassian.net/browse/CR-2862