### PR TITLE
[nomerge] Revert to v3.0.1 to diagnose build failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@ reports/*
 
 # OS detritus
 *.DS_Store
-
-# Virtual environment
-/venv/

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+Ned Batchelder <ned@nedbatchelder.com>
+Will Daly <will@edx.org>
+Brian Wilson <brian@edx.org>
+Julia Hansbrough <julia@edx.org>
+James Tauber <jtauber@jtauber.com>
+Piotr Mitros <pmitros@edx.org>
+Feanil Patel <feanil@edx.org>
+Dave St.Germain <dstgermain@edx.org>

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,3 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/tox.txt requirements/tox.in
 	pip-compile --upgrade -o requirements/testing.txt requirements/testing.in
 	pip-compile --upgrade -o requirements/sandbox.txt requirements/sandbox.in
-
-quality: ## check coding style with pycodestyle and pylint
-	pycodestyle codejail *.py
-	isort --check-only --diff --recursive codejail *.py
-	pylint codejail *.py

--- a/codejail/django_integration.py
+++ b/codejail/django_integration.py
@@ -4,13 +4,12 @@ Code to glue codejail into a Django environment.
 
 """
 
-# pylint: skip-file
-
-from django.conf import settings
+from __future__ import absolute_import
 from django.core.exceptions import MiddlewareNotUsed
+from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
-from . import django_integration_utils
+import codejail.jail_code
 
 
 class ConfigureCodeJailMiddleware(MiddlewareMixin):
@@ -20,8 +19,18 @@ class ConfigureCodeJailMiddleware(MiddlewareMixin):
     This is a Django idiom to have code run once on server startup: put the
     code in the `__init__` of some middleware, and have it do the work, then
     raise `MiddlewareNotUsed` to disable the middleware.
+
     """
     def __init__(self, *args, **kwargs):
-        django_integration_utils.apply_django_settings(settings.CODE_JAIL)
+        python_bin = settings.CODE_JAIL.get('python_bin')
+        if python_bin:
+            user = settings.CODE_JAIL['user']
+            codejail.jail_code.configure("python", python_bin, user=user)
+
+        limits = settings.CODE_JAIL.get('limits', {})
+        for name, value in limits.items():
+            codejail.jail_code.set_limit(name, value)
+
         super(ConfigureCodeJailMiddleware, self).__init__(*args, **kwargs)
+
         raise MiddlewareNotUsed

--- a/codejail/subproc.py
+++ b/codejail/subproc.py
@@ -1,5 +1,6 @@
 """Subprocess helpers for CodeJail."""
 
+from __future__ import absolute_import
 import functools
 import logging
 import os
@@ -12,8 +13,8 @@ log = logging.getLogger("codejail")
 
 
 def run_subprocess(
-        cmd, stdin=None, cwd=None, env=None, rlimits=None, realtime=None,
-        slug=None,
+    cmd, stdin=None, cwd=None, env=None, rlimits=None, realtime=None,
+    slug=None,
 ):
     """
     A helper to make a limited subprocess.
@@ -36,11 +37,11 @@ def run_subprocess(
     the stdout and stderr of the process, as strings.
 
     """
-    subproc = subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn
+    subproc = subprocess.Popen(
         cmd, cwd=cwd, env=env,
         preexec_fn=functools.partial(set_process_limits, rlimits or ()),
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-    )
+        )
 
     if slug:
         log.info("Executed jailed code %s in %s, with PID %s", slug, cwd, subproc.pid)

--- a/codejail/tests/doit.py
+++ b/codejail/tests/doit.py
@@ -1,6 +1,5 @@
-# pylint: skip-file isort:skip_file
-from __future__ import absolute_import, print_function
-
+from __future__ import absolute_import
+from __future__ import print_function
 import sys
 
 print("This is doit.py!")

--- a/codejail/tests/test_json_safe.py
+++ b/codejail/tests/test_json_safe.py
@@ -2,12 +2,11 @@
 Test JSON serialization straw
 """
 
+from __future__ import absolute_import
 import unittest
-
+from codejail.safe_exec import json_safe
 from six import unichr
 from six.moves import range
-
-from codejail.safe_exec import json_safe
 
 
 class JsonSafeTest(unittest.TestCase):

--- a/codejail/tests/test_safe_exec.py
+++ b/codejail/tests/test_safe_exec.py
@@ -1,25 +1,26 @@
 """Test safe_exec.py"""
 
+from __future__ import absolute_import
 import os.path
 import textwrap
 import zipfile
-from builtins import bytes
-from io import BytesIO
 from unittest import SkipTest, TestCase
 
 import six
-
-from codejail import safe_exec
-from codejail.jail_code import set_limit
+from builtins import bytes
 
 try:
     from cStringIO import StringIO
 except ImportError:
-    from io import StringIO  # pylint: disable=ungrouped-imports
+    from io import StringIO
+from io import BytesIO
+
+from codejail import safe_exec
+from codejail.jail_code import set_limit
+
 
 
 class TestJsonSafe(TestCase):
-    # pylint: disable=missing-class-docstring
     def test_decodable_dict(self):
         test_dict = {1: bytes('a', 'utf8'), 2: 'b', 3: {1: bytes('b', 'utf8'), 2: (1, bytes('a', 'utf8'))}}
         cleaned_dict = safe_exec.json_safe(test_dict)
@@ -123,7 +124,7 @@ class SafeExecTests(TestCase):
         msg = str(what_happened.exception)
         # The result may be repr'd or not, so the backslash needs to be
         # optional in this match.
-        self.assertRegex(
+        self.assertRegexpMatches(
             msg,
             r"ValueError: That\\?'s not how you pour soup!"
         )

--- a/codejail/util.py
+++ b/codejail/util.py
@@ -1,5 +1,6 @@
 """Helpers for codejail."""
 
+from __future__ import absolute_import
 import contextlib
 import os
 import shutil

--- a/memory_stress.py
+++ b/memory_stress.py
@@ -1,14 +1,13 @@
 """Memory-stress a long-running CodeJail-using process."""
 
-from six.moves import range
-
+from __future__ import absolute_import
+from __future__ import print_function
 from codejail import safe_exec
+from six.moves import range
 
 GOBBLE_CHUNK = int(1e7)
 
-
 def main():
-    # pylint: disable=missing-function-docstring
     gobble = []
     for i in range(int(1e7)):
         print(i)
@@ -17,7 +16,6 @@ def main():
         assert globs["a"] == 17
 
         gobble.append("x"*GOBBLE_CHUNK)
-
 
 if __name__ == "__main__":
     main()

--- a/proxy_main.py
+++ b/proxy_main.py
@@ -1,5 +1,6 @@
 """The main program for the proxy process."""
 
+from __future__ import absolute_import
 import sys
 
 from codejail.proxy import proxy_main

--- a/pylintrc
+++ b/pylintrc
@@ -34,9 +34,10 @@ load-plugins=
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
 disable=
-
 # Never going to use these
-# C0301: Line too long; pycodestyle handles this for us
+# W0142: Used * or ** magic
+# W0141: Used builtin function 'map'
+# I0011: 36,0: Locally disabling E1101
 
 # Might use these when the code is in better shape
 # C0302: Too many lines in module
@@ -49,7 +50,7 @@ disable=
 # R0912: Too many branches
 # R0913: Too many arguments
 # R0914: Too many local variables
-    C0301,C0302,R0201,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914
+    I0011,C0302,W0141,W0142,R0201,R0901,R0902,R0903,R0904,R0911,R0912,R0913,R0914
 
 
 [REPORTS]

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,8 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="3.1.0",
+    version="3.0.1",
     packages=['codejail'],
-    install_requires=['six'],
     zip_safe=False,
     classifiers=[
         "License :: OSI Approved :: Apache Software License",

--- a/tox.ini
+++ b/tox.ini
@@ -18,11 +18,3 @@ commands =
     make test_no_proxy
     make clean
     make test_proxy
-
-[testenv:quality]
-whitelist_externals =
-    make
-deps =
-    -rrequirements/testing.txt
-commands =
-    make quality


### PR DESCRIPTION
Jenkins builds are failing after I merged https://github.com/edx/jenkins-job-dsl/pull/1166 and https://github.com/edx/jenkins-job-dsl/pull/1167.

This PR reverts codejail to `3.0.1`, a version that we know had a passing build, to isolate the potential build issues.