### PR TITLE
Fix 'Preparing to execute jailed code' log message

### DIFF
--- a/codejail/jail_code.py
+++ b/codejail/jail_code.py
@@ -292,17 +292,14 @@ def jail_code(command, code=None, files=None, extra_files=None, argv=None,
 
         # Determine effective resource limits.
         effective_limits = get_effective_limits(limit_overrides_context)
-        limit_overrides_log_string = (
-            " (using overrides context '{}'')".format(limit_overrides_context)
-            if limit_overrides_context
-            else ""
-        )
-        log.info(
-            "Preparing to execute jailed code %s%s with resource limits: %r",
-            jail_code,
-            limit_overrides_log_string,
-            effective_limits,
-        )
+        if slug:
+            log.info(
+                "Preparing to execute jailed code %r "
+                "(overrides context = %r, resource limits = %r).",
+                slug,
+                limit_overrides_context,
+                effective_limits,
+            )
 
         # Use the configuration and maybe an environment variable to determine
         # whether to use a proxy process.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="codejail",
-    version="3.1.2",
+    version="3.1.3",
     packages=['codejail'],
     install_requires=['six'],
     zip_safe=False,


### PR DESCRIPTION
```
The logging statement added in 3.1.1, and modified in
3.1.2, was typoed.

Bump version to 3.1.3
```

Whoops, the logging message I added in https://github.com/edx/codejail/pull/103 was messed up. This fixes it, and also simplifies the logging statement itself a bit.

The corresponding edx-platform version bump is here: https://github.com/edx/edx-platform/pull/25540

https://openedx.atlassian.net/browse/TNL-7649
