### PR TITLE
build: update package name to edx-codejail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ with open('README.rst') as readme:
     long_description = readme.read()
 
 setup(
-    name="codejail",
-    version="3.1.4",
+    name="edx-codejail",
+    version="3.1.5",
     license='Apache',
     description='CodeJail manages execution of untrusted code in secure sandboxes. It is designed primarily for '
                 'Python execution, but can be used for other languages as well.',


### PR DESCRIPTION
Updates name of the package to edx-codejail as codejail isn't allowed on PyPI
For reference https://github.com/edx/codejail/runs/2352964134?check_suite_focus=true#step:8:25